### PR TITLE
Remove addAttachedArtifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,15 @@
 	<description>A customized maven-javadoc-plugin</description>
 	<url>http://frankframework.org</url>
 
+	<properties>
+		<revision>1.1-SNAPSHOT</revision>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+
+		<maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
+	</properties>
+
 	<organization>
 		<name>Frank!Framework</name>
 		<url>https://frankframework.org</url>
@@ -42,15 +51,6 @@
 		<connection>scm:git:https://github.com/frankframework/frank-doc-plugin.git</connection>
 		<tag>HEAD</tag>
 	</scm>
-
-	<properties>
-		<revision>1.0-SNAPSHOT</revision>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.target>11</maven.compiler.target>
-		<maven.compiler.source>11</maven.compiler.source>
-
-		<maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
-	</properties>
 
 	<dependencyManagement>
 		<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
 			</repositories>
 		</profile>
 		<profile>
-			<id>sign</id>
+			<id>ossrh</id>
 			<build>
 				<plugins>
 					<plugin>
@@ -299,40 +299,19 @@
 							</execution>
 						</executions>
 					</plugin>
-				</plugins>
-			</build>
-		</profile>
-		<profile>
-			<id>ossrh</id>
-			<build>
-				<plugins>
 					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>1.6.13</version>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<version>0.7.0</version>
 						<extensions>true</extensions>
 						<configuration>
-							<serverId>ossrh</serverId>
-							<nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-							<autoReleaseAfterClose>false</autoReleaseAfterClose>
+							<autoPublish>false</autoPublish><!-- Don't release the build directly after it's been published to Central (staging). -->
+							<publishingServerId>ossrh</publishingServerId>
+							<waitUntil>validated</waitUntil><!-- Wait until the deployment bundle has been uploaded and validated. -->
 						</configuration>
 					</plugin>
 				</plugins>
 			</build>
-			<distributionManagement>
-				<repository>
-					<id>ossrh</id>
-					<url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-				</repository>
-				<snapshotRepository>
-					<id>ossrh</id>
-					<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-				</snapshotRepository>
-				<site>
-					<id>www.frankframework.org</id>
-					<url>file:target/site-deploy</url>
-				</site>
-			</distributionManagement>
 		</profile>
 	</profiles>
 </project>

--- a/src/main/java/org/frankframework/maven/FrankDocPluginMojo.java
+++ b/src/main/java/org/frankframework/maven/FrankDocPluginMojo.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021-2023 WeAreFrank!
+   Copyright 2021-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ public class FrankDocPluginMojo extends AggregatorJavadocJar {
 		List<Artifact> artifacts = project.getAttachedArtifacts();
 		for(Artifact artifact : artifacts) {
 			if(getClassifier().equals(artifact.getClassifier()) && project.getArtifact().getVersion().equals(artifact.getVersion())) {
-				addAttachedArtifact(artifact); // We found the Frank!Doc artifact
+				addFrankDocResourcesToArtifact(artifact); // We found the Frank!Doc artifact
 			}
 		}
 	}
@@ -134,7 +134,11 @@ public class FrankDocPluginMojo extends AggregatorJavadocJar {
 		}
 	}
 
-	private void addAttachedArtifact(Artifact artifact) {
+	/**
+	 * Add the frontend resources and the Frank!Doc XSDs and the element summary to the submodule that matches the appendTo parameter.
+	 * By default this is the core-module.
+	 */
+	private void addFrankDocResourcesToArtifact(Artifact artifact) {
 		if(appendTo == null) {
 			return;
 		}
@@ -144,16 +148,15 @@ public class FrankDocPluginMojo extends AggregatorJavadocJar {
 				File frankdoc = artifact.getFile();
 				getLog().info("Found Frank!Doc artifact [" + frankdoc + "]");
 
-				reactorProject.addResource(createFrontendResources());
-				reactorProject.addResource(createCompatibilityResource());
-				reactorProject.addAttachedArtifact(artifact);
+				reactorProject.addResource(createXsdsResource());
+				reactorProject.addResource(createStaticFrontendResources());
 
 				break;
 			}
 		}
 	}
 
-	private Resource createCompatibilityResource() {
+	private Resource createXsdsResource() {
 		Resource resource = new Resource();
 		resource.setDirectory(getOutputDirectory());
 		resource.addInclude(FRANK_CONFIG_COMPATIBILITY);
@@ -163,7 +166,7 @@ public class FrankDocPluginMojo extends AggregatorJavadocJar {
 		return resource;
 	}
 
-	private Resource createFrontendResources() {
+	private Resource createStaticFrontendResources() {
 		Resource resource = new Resource();
 		resource.setDirectory(getOutputDirectory());
 		resource.addExclude(FRANK_CONFIG_COMPATIBILITY);


### PR DESCRIPTION
Should fix `Failed to process ****: Error on building manifests: File with path '/tmp/deployed-archive-utils16152685308950958504/org/frankframework/frankframework-core/9.2.0/frankframework-core-9.2.0-frankdoc.jar' is missing`

Also includes [Use the new Sonatype 'deploy to central' plugin](https://github.com/frankframework/frankframework/pull/8944).